### PR TITLE
bootstrap 4.3 expects -append, but datepicker expects -addon

### DIFF
--- a/lib/time_wrapper/simple_form_wrapper.rb
+++ b/lib/time_wrapper/simple_form_wrapper.rb
@@ -5,8 +5,10 @@
     b.use :label, class: 'form-control-label'
     b.wrapper tag: 'div', class: 'input-group time timepicker' do |input|
       input.use :input, class: 'form-control', autocomplete: :off
-      input.wrapper tag: 'span', class: 'input-group-addon' do |addon|
-        addon.wrapper tag: 'i', class: "fa fa-clock-o" do |_|
+      input.wrapper tag: 'span', class: 'input-group-addon input-group-append' do |addon|
+        addon.wrapper tag: 'span', class: 'input-group-text' do |text|
+          text.wrapper tag: 'i', class: "fa fa-clock-o" do |_|
+          end
         end
       end
     end


### PR DESCRIPTION
http://eonasdan.github.io/bootstrap-datetimepicker is not maintained anymore, and bootstrap 4.3 has changed how input groups work.

So this should fix so input groups is displayed correctly in latest bootstrap, but also so that time picker can find a -addon class.